### PR TITLE
Introduce new syntax for contract methods call

### DIFF
--- a/spec/ethereum/contract_blockchain_spec.rb
+++ b/spec/ethereum/contract_blockchain_spec.rb
@@ -7,18 +7,18 @@ describe Ethereum do
 
   it "should build, deploy, call methods, receive events and kill contract", slow: true do
     @works = Ethereum::Contract.from_file(path, client)
-    expect(@works.estimate()).to be > 100
+    expect(@works.estimate).to be > 100
     contract_address = @works.deploy_and_wait
 
     filter_id = @works.nf_changed address: contract_address, topics: []
-    tx_address = @works.transact_and_wait_set("some4key", "somethevalue").address
+    tx_address = @works.transact_and_wait.set("some4key", "somethevalue").address
     expect(@works.gfc_changed(filter_id)[0][:transactionHash]).to eq tx_address
     expect(@works.gfl_changed(filter_id)[0][:transactionHash]).to eq tx_address
     expect(Ethereum::Transaction.from_blockchain(tx_address).mined?).to be true
 
     @works_reloaded = Ethereum::Contract.from_blockchain("WorksReloaded", contract_address, @works.abi, client)
-    expect(@works_reloaded.call_get("some4key")).to eq ["somethevalue", "żółć"]
-    expect(@works.transact_and_wait_kill.mined?).to be true
+    expect(@works_reloaded.call.get("some4key")).to eq ["somethevalue", "żółć"]
+    expect(@works.transact_and_wait.kill.mined?).to be true
   end
 
 end

--- a/spec/ethereum/contract_blockchain_spec.rb
+++ b/spec/ethereum/contract_blockchain_spec.rb
@@ -10,10 +10,10 @@ describe Ethereum do
     expect(@works.estimate).to be > 100
     contract_address = @works.deploy_and_wait
 
-    filter_id = @works.nf_changed address: contract_address, topics: []
+    filter_id = @works.new_filter.changed address: contract_address, topics: []
     tx_address = @works.transact_and_wait.set("some4key", "somethevalue").address
-    expect(@works.gfc_changed(filter_id)[0][:transactionHash]).to eq tx_address
-    expect(@works.gfl_changed(filter_id)[0][:transactionHash]).to eq tx_address
+    expect(@works.get_filter_changes.changed(filter_id)[0][:transactionHash]).to eq tx_address
+    expect(@works.get_filter_logs.changed(filter_id)[0][:transactionHash]).to eq tx_address
     expect(Ethereum::Transaction.from_blockchain(tx_address).mined?).to be true
 
     @works_reloaded = Ethereum::Contract.from_blockchain("WorksReloaded", contract_address, @works.abi, client)

--- a/spec/ethereum/contract_event_spec.rb
+++ b/spec/ethereum/contract_event_spec.rb
@@ -18,7 +18,7 @@ describe Ethereum::Contract do
     let(:contract) { Ethereum::Contract.from_file(path, client) }
     it "succeed" do
       expect(client).to receive(:send_single).once.with(eth_send_request).and_return(eth_send_result)
-      expect(contract.nf_changed address: "70783C3CFaf354F425D85c1E8a5EfE4586C64b5D").to eq 2 
+      expect(contract.new_filter.changed address: "70783C3CFaf354F425D85c1E8a5EfE4586C64b5D").to eq 2 
     end
   end
 
@@ -29,7 +29,7 @@ describe Ethereum::Contract do
     let(:contract) { Ethereum::Contract.from_file(path, client) }
     it "succeed" do
       expect(client).to receive(:send_single).once.with(eth_send_request).and_return(eth_send_result)
-      expect(contract.gfl_changed(7)[0]).to include expected
+      expect(contract.get_filter_logs.changed(7)[0]).to include expected
     end
   end
 
@@ -40,7 +40,7 @@ describe Ethereum::Contract do
     let(:contract) { Ethereum::Contract.from_file(path, client) }
     it "succeed" do
       expect(client).to receive(:send_single).once.with(eth_send_request).and_return(eth_send_result)
-      expect(contract.gfc_changed(7)[0]).to include expected
+      expect(contract.get_filter_changes.changed(7)[0]).to include expected
     end
   end
 end

--- a/spec/ethereum/contract_spec.rb
+++ b/spec/ethereum/contract_spec.rb
@@ -51,7 +51,7 @@ describe Ethereum::Contract do
   context "transact" do
     let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae3217"}],"id":1}' }
     let(:eth_send_result) { '{"jsonrpc":"2.0","result":"0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623","id":1}' }
-    subject { expect(contract.transact_greet.id).to eq '0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623' }
+    subject { expect(contract.transact.greet.id).to eq '0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623' }
     it_behaves_like "communicate with node"
   end
 
@@ -63,21 +63,21 @@ describe Ethereum::Contract do
       contract.at(address)
       expect(client).to receive(:send_single).once.with(eth_send_request).and_return(eth_send_result)
       expect(client).to receive(:send_single).once.with(eth_get_transaction_request).and_return(eth_get_transaction_result)
-      contract.transact_and_wait_greet
+      contract.transact_and_wait.greet
     end
   end
 
   context "call" do
     let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae3217"},"latest"],"id":1}' }
     let(:eth_send_result) { '{"jsonrpc":"2.0", "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003616c610000000000000000000000000000000000000000000000000000000000", "id": 1}' }
-    subject { expect(contract.call_greet).to eq "ala" }
+    subject { expect(contract.call.greet).to eq "ala" }
     it_behaves_like "communicate with node"
   end
 
   context "call_raw" do
     let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae3217"},"latest"],"id":1}' }
     let(:eth_send_result) { '{"jsonrpc":"2.0", "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003616c610000000000000000000000000000000000000000000000000000000000", "id": 1}' }
-    subject { expect(contract.call_raw_greet[:formatted]).to eq ["ala"] }
+    subject { expect(contract.call_raw.greet[:formatted]).to eq ["ala"] }
     it_behaves_like "communicate with node"
   end
 

--- a/spec/ethereum/contract_spec.rb
+++ b/spec/ethereum/contract_spec.rb
@@ -17,7 +17,7 @@ describe Ethereum::Contract do
 
   shared_examples "communicate with node" do |expected|
     it "communicate with node" do
-      contract.at(address)
+      contract.address = address
       expect(client).to receive(:send_single).once.with(eth_send_request).and_return(eth_send_result)
       subject
     end
@@ -60,7 +60,7 @@ describe Ethereum::Contract do
     let(:eth_get_transaction_request) { '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":[""],"id":1}' }
     let(:eth_get_transaction_result) { '{"jsonrpc":"2.0","result":{"blockHash":"0xc1e5032da79990789fb6933d31fb5670e66aec1e88fa98efbc1c9d4507c070ab","blockNumber":"0x56893","creates":null,"from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","gas":"0xe57e0","gasPrice":"0x4a817c800","hash":"0x528b3c18433ea9b9089f0eef1f5be722934e629e441fa1af07f33531b20c22c9","input":"0x41c0e1b5","nonce":"0x25","publicKey":"0xccfdb8fdcf107fa9aa3fbaef7bc33c97685a7ab61f9cbef8e510fff848930b444e0ae2e66b27326b95cab0ff070c1db793f396c646ae2cb17ad539f41af23099","r":"0x07139d16062f86f003836a6b41ff2fba5c8988daa745c44cddeb807f7c5dee5e","raw":"0xf869258504a817c800830e57e0945b1141d29fad616d221fff559dcaa11bbb2ebcb7808441c0e1b52aa007139d16062f86f003836a6b41ff2fba5c8988daa745c44cddeb807f7c5dee5ea0415b0bdbc6bee69a8e6518abe914ae29a4f0a4a23f7aa9683f4fe5b16bafc0d9","s":"0x415b0bdbc6bee69a8e6518abe914ae29a4f0a4a23f7aa9683f4fe5b16bafc0d9","to":"0x5b1141d29fad616d221fff559dcaa11bbb2ebcb7","transactionIndex":"0x3","v":1,"value":"0x0"},"id":1}' }
     it "communicate with node" do
-      contract.at(address)
+      contract.address = address
       expect(client).to receive(:send_single).once.with(eth_send_request).and_return(eth_send_result)
       expect(client).to receive(:send_single).once.with(eth_get_transaction_request).and_return(eth_get_transaction_result)
       contract.transact_and_wait.greet


### PR DESCRIPTION
Introduce new syntax for contract methods call.
Before:
contract.call_name(args)
contract.nf_changed(args) 

After:
contract.call.name(args)
contract.new_filter.changed(args)

Finalise refactoring of contract class and dynamic proxies.