### PR TITLE
Only add sender to args is @sender is set

### DIFF
--- a/lib/ethereum/client.rb
+++ b/lib/ethereum/client.rb
@@ -53,7 +53,7 @@ module Ethereum
     end
 
     def default_account
-      @default_account || eth_accounts["result"][0]
+      @default_account || eth_accounts["result"].try(:[], 0)
     end
 
     def int_to_hex(p)

--- a/lib/ethereum/contract.rb
+++ b/lib/ethereum/contract.rb
@@ -110,7 +110,9 @@ module Ethereum
     end
 
     def call_args(fun, args)
-      add_gas_options_args({to: @address, from: @sender, data: call_payload(fun, args)})
+      params = {to: @address, data: call_payload(fun, args)}
+      params[:from] = @sender if @sender
+      add_gas_options_args(params)
     end
 
     def call_raw(fun, *args)


### PR DESCRIPTION
I'm using the `Ethereum::HttpClient` with an Ethereum RPC url provided by <https://infura.io>. I'm not running a local Ethereum node at all.

This works well without setting a "from" address, with this patch. 

Let me know your thoughts.  I can probably find time to write a test if you approve of the general direction.

Thanks for a great library!